### PR TITLE
Fix descriptions for publishing

### DIFF
--- a/actions/auth-k8s/action.yml
+++ b/actions/auth-k8s/action.yml
@@ -1,5 +1,5 @@
 name: 'Teleport Auth (Kubernetes)'
-description: "Authenticates your workflow so it can use tools like `kubectl` against Kubernetes clusters protected by Teleport."
+description: 'Authenticates your workflow so it can use tools like `kubectl` against Kubernetes clusters protected by Teleport.'
 inputs:
   kubernetes-cluster:
     description: 'Specify the name of the Kubernetes cluster in Teleport you wish to connect to.'

--- a/actions/auth-k8s/action.yml
+++ b/actions/auth-k8s/action.yml
@@ -1,5 +1,5 @@
-name: 'Teleport Auth Kubernetes'
-description: 'Uses Machine ID to fetch credentials for use with a Kubernetes cluster. Automatically configure `KUBE_CONFIG` environment variable so invocations of `kubectl` and similar tools work as expected.'
+name: 'Teleport Auth (Kubernetes)'
+description: "Authenticates your workflow so it can use tools like `kubectl` against Kubernetes clusters protected by Teleport."
 inputs:
   kubernetes-cluster:
     description: 'Specify the name of the Kubernetes cluster in Teleport you wish to connect to.'

--- a/actions/auth/action.yml
+++ b/actions/auth/action.yml
@@ -1,4 +1,4 @@
 name: 'Teleport Auth'
-description: 'Uses Machine ID to fetch credentials for use with `tctl` and `tsh`. Automatically configures `tctl` and `tsh` to use these credentials in following steps.'
+description: "Authenticates your workflow so it can use Teleport's `tctl` and `tsh` with the magic of Machine ID."
 extend:
   - from: '@/common/action.yml'


### PR DESCRIPTION
Unfortunately, our current descriptions are too long for use with the GitHub Actions Marketplace.