### PR TITLE
Add Application Access Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Find out more about our actions in their individual repos:
 - [`teleport-actions/setup`](https://github.com/teleport-actions/setup)
 - [`teleport-actions/auth`](https://github.com/teleport-actions/auth)
 - [`teleport-actions/auth-k8s`](https://github.com/teleport-actions/auth-k8s)
+- [`teleport-actions/auth-application`](https://github.com/teleport-actions/auth-application)
 
 ## Developing
 

--- a/actions/auth-application/README.md
+++ b/actions/auth-application/README.md
@@ -45,7 +45,7 @@ steps:
       version: 11.0.3
   - name: Fetch application credentials
     id: auth
-    uses: teleport-actions/auth-k8s@v1
+    uses: teleport-actions/auth-application@v1
     with:
       # Specify the publically accessible address of your Teleport proxy.
       proxy: tele.example.com:443

--- a/actions/auth-application/README.md
+++ b/actions/auth-application/README.md
@@ -12,37 +12,39 @@
 
 > Read our Documentation: <https://goteleport.com/docs/getting-started/>
 
-# `teleport-actions/auth-k8s`
+# `teleport-actions/auth-application`
 
-`auth-k8s` uses Teleport Machine ID to generate an authorized Kubernetes client
-configuration for a specified cluster protected by Teleport.
+`auth-application` uses Teleport Machine ID to generate an credentials for
+accessing an application protected by Teleport.
 
-The action sets the `KUBECONFIG` environment variable for consecutive steps in
-the job, meaning that tools like `kubectl` will automatically connect to the
-requested Kubernetes cluster without additional configuration.
+The action has the following outputs:
+
+- `certificate-file`: the path to the client certificate to use with requests to
+  the application.
+- `key-file`: the path to the private key for the client certificate to use with
+  request to the application.
 
 Pre-requisites:
 
 - Teleport 11 or above must be used.
 - Teleport binaries must already be installed in the job environment.
-- The Kubernetes cluster you wish to access must already be connected to your
-  Teleport cluster. See
-  <https://goteleport.com/docs/kubernetes-access/getting-started/>
-- You must have created a bot with a role with access to your Kubernetes cluster
-  and created a GitHub join token that allows that bot to join.
+- The Applicatiom you wish to access must already be connected to your Teleport
+  cluster. See
+  <https://goteleport.com/docs/application-access/getting-started/>
+- You must have created a bot with a role with access to your Application and
+  created a GitHub join token that allows that bot to join.
 - A Linux based runner.
 
 Example usage:
 
 ```yaml
 steps:
-  - name: Install Kubectl
-    uses: azure/setup-kubectl@v3
   - name: Install Teleport
     uses: teleport-actions/setup@v1
     with:
       version: 11.0.3
-  - name: Authorize against Teleport
+  - name: Fetch application credentials
+    id: auth
     uses: teleport-actions/auth-k8s@v1
     with:
       # Specify the publically accessible address of your Teleport proxy.
@@ -52,8 +54,8 @@ steps:
       # Specify the length of time that the generated credentials should be
       # valid for. This is optional and defaults to "1h"
       certificate-ttl: 1h
-      # Specify the name of the Kubernetes cluster you wish to access.
-      kubernetes-cluster: my-kubernetes-cluster
-  - name: List pods
-    run: kubectl get pods
+      # Specify the name of the application you wish to access.
+      app: grafana-example
+  - name: Make request
+    run: curl --cert {{ steps.auth.outputs.certificate-file }} --key {{ steps.auth.outputs.key-file }} https://grafana-example.tele.example.com/api/users
 ```

--- a/actions/auth-application/README.md
+++ b/actions/auth-application/README.md
@@ -14,7 +14,7 @@
 
 # `teleport-actions/auth-application`
 
-`auth-application` uses Teleport Machine ID to generate an credentials for
+`auth-application` uses Teleport Machine ID to generate credentials for
 accessing an application protected by Teleport.
 
 The action has the following outputs:

--- a/actions/auth-application/action.yml
+++ b/actions/auth-application/action.yml
@@ -1,0 +1,8 @@
+name: 'Teleport Auth (Application Access)'
+description: 'Generates credentials so that your workflow can access applications protected by Teleport.'
+inputs:
+  app:
+    description: 'Specify the name of the application in Teleport you wish to generate credentials for.'
+    required: true
+extend:
+  - from: '@/common/action.yml'

--- a/actions/auth-application/package.json
+++ b/actions/auth-application/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "auth-application",
+  "version": "1.0.2",
+  "license": "Apache-2.0",
+  "repository": "https://github.com/teleport-actions/auth-application.git",
+  "scripts": {
+    "build": "ncc build ./src/index.ts -o dist"
+  },
+  "dependencies": {
+    "@actions/core": "^1.10.0",
+    "@actions/tool-cache": "^2.0.1"
+  },
+  "private": true,
+  "devDependencies": {
+    "@types/node": "^18.8.2"
+  }
+}

--- a/actions/auth-application/package.json
+++ b/actions/auth-application/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-application",
-  "version": "1.0.2",
+  "version": "1.0.0",
   "license": "Apache-2.0",
   "repository": "https://github.com/teleport-actions/auth-application.git",
   "scripts": {

--- a/actions/auth-application/src/index.ts
+++ b/actions/auth-application/src/index.ts
@@ -1,0 +1,41 @@
+import path from 'path';
+
+import * as core from '@actions/core';
+
+import * as tbot from '@root/lib/tbot';
+import * as io from '@root/lib/io';
+
+interface Inputs {
+  app: string;
+}
+
+function getInputs(): Inputs {
+  return {
+    app: core.getInput('app', {
+      required: true,
+    }),
+  };
+}
+
+async function run() {
+  const inputs = getInputs();
+  const sharedInputs = tbot.getSharedInputs();
+  const config = tbot.baseConfigurationFromSharedInputs(sharedInputs);
+
+  // Inject a destination for the Application Access credentials
+  const destinationPath = await io.makeTempDirectory();
+  config.destinations.push({
+    directory: {
+      path: destinationPath,
+    },
+    roles: [], // Use all assigned to bot,
+    app: inputs.app,
+  });
+
+  const configPath = await tbot.writeConfiguration(config);
+  await tbot.execute(configPath);
+
+  core.setOutput('certificate-file', path.join(destinationPath, 'tlscert'));
+  core.setOutput('key-file', path.join(destinationPath, 'key'));
+}
+run().catch(core.setFailed);

--- a/common/lib/tbot.ts
+++ b/common/lib/tbot.ts
@@ -34,6 +34,7 @@ export interface ConfigurationV1Destination {
   };
   roles: Array<string>;
   kubernetes_cluster?: string;
+  app?: string;
 }
 export interface ConfigurationV1 {
   auth_server: string;


### PR DESCRIPTION
Closes #19 

```yaml
steps:
  - name: Install Teleport
    uses: teleport-actions/setup@v1
    with:
      version: 11.0.3
  - name: Fetch application credentials
    id: auth
    uses: teleport-actions/auth-application@v1
    with:
      # Specify the publically accessible address of your Teleport proxy.
      proxy: tele.example.com:443
      # Specify the name of the join token for your bot.
      token: my-github-join-token-name
      # Specify the length of time that the generated credentials should be
      # valid for. This is optional and defaults to "1h"
      certificate-ttl: 1h
      # Specify the name of the application you wish to access.
      app: grafana-example
  - name: Make request
    run: curl --cert {{ steps.auth.outputs.certificate-file }} --key {{ steps.auth.outputs.key-file }} https://grafana-example.tele.example.com/api/users
```