### PR TITLE
Improve provided usage examples in READMEs

### DIFF
--- a/actions/auth-application/README.md
+++ b/actions/auth-application/README.md
@@ -38,24 +38,31 @@ Pre-requisites:
 Example usage:
 
 ```yaml
-steps:
-  - name: Install Teleport
-    uses: teleport-actions/setup@v1
-    with:
-      version: 11.0.3
-  - name: Fetch application credentials
-    id: auth
-    uses: teleport-actions/auth-application@v1
-    with:
-      # Specify the publically accessible address of your Teleport proxy.
-      proxy: tele.example.com:443
-      # Specify the name of the join token for your bot.
-      token: my-github-join-token-name
-      # Specify the length of time that the generated credentials should be
-      # valid for. This is optional and defaults to "1h"
-      certificate-ttl: 1h
-      # Specify the name of the application you wish to access.
-      app: grafana-example
-  - name: Make request
-    run: curl --cert {{ steps.auth.outputs.certificate-file }} --key {{ steps.auth.outputs.key-file }} https://grafana-example.tele.example.com/api/users
+on:
+  workflow_dispatch: {}
+jobs:
+  demo-auth-application:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+    - name: Install Teleport
+      uses: teleport-actions/setup@v1
+      with:
+        version: 11.0.3
+    - name: Fetch application credentials
+      id: auth
+      uses: teleport-actions/auth-application@v1
+      with:
+        # Specify the publically accessible address of your Teleport proxy.
+        proxy: tele.example.com:443
+        # Specify the name of the join token for your bot.
+        token: my-github-join-token-name
+        # Specify the length of time that the generated credentials should be
+        # valid for. This is optional and defaults to "1h"
+        certificate-ttl: 1h
+        # Specify the name of the application you wish to access.
+        app: grafana-example
+    - name: Make request
+      run: curl --cert ${{ steps.auth.outputs.certificate-file }} --key ${{ steps.auth.outputs.key-file }} https://grafana-example.tele.example.com/api/users
 ```

--- a/actions/auth-application/README.md
+++ b/actions/auth-application/README.md
@@ -46,23 +46,23 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - name: Install Teleport
-      uses: teleport-actions/setup@v1
-      with:
-        version: 11.0.3
-    - name: Fetch application credentials
-      id: auth
-      uses: teleport-actions/auth-application@v1
-      with:
-        # Specify the publically accessible address of your Teleport proxy.
-        proxy: tele.example.com:443
-        # Specify the name of the join token for your bot.
-        token: my-github-join-token-name
-        # Specify the length of time that the generated credentials should be
-        # valid for. This is optional and defaults to "1h"
-        certificate-ttl: 1h
-        # Specify the name of the application you wish to access.
-        app: grafana-example
-    - name: Make request
-      run: curl --cert ${{ steps.auth.outputs.certificate-file }} --key ${{ steps.auth.outputs.key-file }} https://grafana-example.tele.example.com/api/users
+      - name: Install Teleport
+        uses: teleport-actions/setup@v1
+        with:
+          version: 11.0.3
+      - name: Fetch application credentials
+        id: auth
+        uses: teleport-actions/auth-application@v1
+        with:
+          # Specify the publically accessible address of your Teleport proxy.
+          proxy: tele.example.com:443
+          # Specify the name of the join token for your bot.
+          token: my-github-join-token-name
+          # Specify the length of time that the generated credentials should be
+          # valid for. This is optional and defaults to "1h"
+          certificate-ttl: 1h
+          # Specify the name of the application you wish to access.
+          app: grafana-example
+      - name: Make request
+        run: curl --cert ${{ steps.auth.outputs.certificate-file }} --key ${{ steps.auth.outputs.key-file }} https://grafana-example.tele.example.com/api/users
 ```

--- a/actions/auth-k8s/README.md
+++ b/actions/auth-k8s/README.md
@@ -35,27 +35,34 @@ Pre-requisites:
 Example usage:
 
 ```yaml
-steps:
-  - name: Install Kubectl
-    uses: azure/setup-kubectl@v3
-  - name: Install Teleport
-    uses: teleport-actions/setup@v1
-    with:
-      version: 11.0.3
-  - name: Authorize against Teleport
-    uses: teleport-actions/auth-k8s@v1
-    with:
-      # Specify the publically accessible address of your Teleport proxy.
-      proxy: tele.example.com:443
-      # Specify the name of the join token for your bot.
-      token: my-github-join-token-name
-      # Specify the length of time that the generated credentials should be
-      # valid for. This is optional and defaults to "1h"
-      certificate-ttl: 1h
-      # Specify the name of the Kubernetes cluster you wish to access.
-      kubernetes-cluster: my-kubernetes-cluster
-  - name: List pods
-    run: kubectl get pods
+on:
+  workflow_dispatch: {}
+jobs:
+  demo-auth-k8s:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+    - name: Install Kubectl
+      uses: azure/setup-kubectl@v3
+    - name: Install Teleport
+      uses: teleport-actions/setup@v1
+      with:
+        version: 11.0.3
+    - name: Authorize against Teleport
+      uses: teleport-actions/auth-k8s@v1
+      with:
+        # Specify the publically accessible address of your Teleport proxy.
+        proxy: tele.example.com:443
+        # Specify the name of the join token for your bot.
+        token: my-github-join-token-name
+        # Specify the length of time that the generated credentials should be
+        # valid for. This is optional and defaults to "1h"
+        certificate-ttl: 1h
+        # Specify the name of the Kubernetes cluster you wish to access.
+        kubernetes-cluster: my-kubernetes-cluster
+    - name: List pods
+      run: kubectl get pods
 ```
 
 ## Next steps

--- a/actions/auth-k8s/README.md
+++ b/actions/auth-k8s/README.md
@@ -43,26 +43,26 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - name: Install Kubectl
-      uses: azure/setup-kubectl@v3
-    - name: Install Teleport
-      uses: teleport-actions/setup@v1
-      with:
-        version: 11.0.3
-    - name: Authorize against Teleport
-      uses: teleport-actions/auth-k8s@v1
-      with:
-        # Specify the publically accessible address of your Teleport proxy.
-        proxy: tele.example.com:443
-        # Specify the name of the join token for your bot.
-        token: my-github-join-token-name
-        # Specify the length of time that the generated credentials should be
-        # valid for. This is optional and defaults to "1h"
-        certificate-ttl: 1h
-        # Specify the name of the Kubernetes cluster you wish to access.
-        kubernetes-cluster: my-kubernetes-cluster
-    - name: List pods
-      run: kubectl get pods
+      - name: Install Kubectl
+        uses: azure/setup-kubectl@v3
+      - name: Install Teleport
+        uses: teleport-actions/setup@v1
+        with:
+          version: 11.0.3
+      - name: Authorize against Teleport
+        uses: teleport-actions/auth-k8s@v1
+        with:
+          # Specify the publically accessible address of your Teleport proxy.
+          proxy: tele.example.com:443
+          # Specify the name of the join token for your bot.
+          token: my-github-join-token-name
+          # Specify the length of time that the generated credentials should be
+          # valid for. This is optional and defaults to "1h"
+          certificate-ttl: 1h
+          # Specify the name of the Kubernetes cluster you wish to access.
+          kubernetes-cluster: my-kubernetes-cluster
+      - name: List pods
+        run: kubectl get pods
 ```
 
 ## Next steps

--- a/actions/auth/README.md
+++ b/actions/auth/README.md
@@ -32,26 +32,33 @@ Pre-requisites:
 Example usage:
 
 ```yaml
-steps:
-  - name: Install Teleport
-    uses: teleport-actions/setup@v1
-    with:
-      version: 11.0.3
-  - name: Authorize against Teleport
-    id: auth
-    uses: teleport-actions/auth@v1
-    with:
-      # Specify the publically accessible address of your Teleport proxy.
-      proxy: tele.example.com:443
-      # Specify the name of the join token for your bot.
-      token: my-github-join-token-name
-      # Specify the length of time that the generated credentials should be
-      # valid for. This is optional and defaults to "1h"
-      certificate-ttl: 1h
-  - name: List nodes (tsh)
-    run: tsh -i ${{ steps.auth.outputs.identity-file }} ls
-  - name: List nodes (tctl)
-    run: tctl -i ${{ steps.auth.outputs.identity-file }} --auth-server tele.example.com:443 nodes ls
+on:
+  workflow_dispatch: {}
+jobs:
+  demo-auth:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Install Teleport
+        uses: teleport-actions/setup@v1
+        with:
+          version: 11.0.3
+      - name: Authorize against Teleport
+        id: auth
+        uses: teleport-actions/auth@v1
+        with:
+          # Specify the publically accessible address of your Teleport proxy.
+          proxy: tele.example.com:443
+          # Specify the name of the join token for your bot.
+          token: my-github-join-token-name
+          # Specify the length of time that the generated credentials should be
+          # valid for. This is optional and defaults to "1h"
+          certificate-ttl: 1h
+      - name: List nodes (tsh)
+        run: tsh -i ${{ steps.auth.outputs.identity-file }} ls
+      - name: List nodes (tctl)
+        run: tctl -i ${{ steps.auth.outputs.identity-file }} --auth-server tele.example.com:443 nodes ls
 ```
 
 Note that `tsh` and `tctl` require the flag pointing at the identity file and

--- a/actions/setup/README.md
+++ b/actions/setup/README.md
@@ -27,11 +27,17 @@ Pre-requisites:
 Example usage:
 
 ```yaml
-steps:
-  - name: Install Teleport
-    uses: teleport-actions/setup@v1
-    with:
-      # version must be specified, and exclude the "v" prefix.
-      # check https://goteleport.com/download/ for valid releases.
-      version: 11.0.3
+on:
+  workflow_dispatch: {}
+jobs:
+  demo-setup:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Teleport
+      uses: teleport-actions/setup@v1
+      with:
+        # version must be specified, and exclude the "v" prefix.
+        # check https://goteleport.com/download/ for valid releases.
+        version: 11.0.3
+    - run: tsh # tsh, tbot and tctl will now be available
 ```

--- a/actions/setup/README.md
+++ b/actions/setup/README.md
@@ -33,11 +33,11 @@ jobs:
   demo-setup:
     runs-on: ubuntu-latest
     steps:
-    - name: Install Teleport
-      uses: teleport-actions/setup@v1
-      with:
-        # version must be specified, and exclude the "v" prefix.
-        # check https://goteleport.com/download/ for valid releases.
-        version: 11.0.3
-    - run: tsh # tsh, tbot and tctl will now be available
+      - name: Install Teleport
+        uses: teleport-actions/setup@v1
+        with:
+          # version must be specified, and exclude the "v" prefix.
+          # check https://goteleport.com/download/ for valid releases.
+          version: 11.0.3
+      - run: tsh # tsh, tbot and tctl will now be available
 ```


### PR DESCRIPTION
Many thanks to @portswigger-tim for pointing this out and providing an improved example for `auth-application`.





