### PR TITLE
Use `try-secure` rather than `secure` for symlink protection

### DIFF
--- a/actions/auth-application/package.json
+++ b/actions/auth-application/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-application",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "Apache-2.0",
   "repository": "https://github.com/teleport-actions/auth-application.git",
   "scripts": {

--- a/actions/auth-application/src/index.ts
+++ b/actions/auth-application/src/index.ts
@@ -29,6 +29,7 @@ async function run() {
   config.destinations.push({
     directory: {
       path: destinationPath,
+      symlinks: 'try-secure',
     },
     roles: [], // Use all assigned to bot,
     app: inputs.app,

--- a/actions/auth-k8s/package.json
+++ b/actions/auth-k8s/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-k8s",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "Apache-2.0",
   "repository": "https://github.com/teleport-actions/auth-k8s.git",
   "scripts": {

--- a/actions/auth-k8s/src/index.ts
+++ b/actions/auth-k8s/src/index.ts
@@ -29,6 +29,7 @@ async function run() {
   config.destinations.push({
     directory: {
       path: destinationPath,
+      symlinks: 'try-secure',
     },
     roles: [], // Use all assigned to bot,
     kubernetes_cluster: inputs.kubernetesCluster,

--- a/actions/auth/package.json
+++ b/actions/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "Apache-2.0",
   "repository": "https://github.com/teleport-actions/auth.git",
   "scripts": {

--- a/actions/auth/src/index.ts
+++ b/actions/auth/src/index.ts
@@ -15,7 +15,7 @@ async function run() {
   config.destinations.push({
     directory: {
       path: destinationPath,
-      symlinks: "try-secure",
+      symlinks: 'try-secure',
     },
     roles: [], // Use all assigned to bot,
   });

--- a/actions/auth/src/index.ts
+++ b/actions/auth/src/index.ts
@@ -15,6 +15,7 @@ async function run() {
   config.destinations.push({
     directory: {
       path: destinationPath,
+      symlinks: "try-secure",
     },
     roles: [], // Use all assigned to bot,
   });

--- a/common/lib/tbot.ts
+++ b/common/lib/tbot.ts
@@ -42,6 +42,7 @@ export function getSharedInputs(): SharedInputs {
 export interface ConfigurationV1Destination {
   directory: {
     path: string;
+    symlinks: 'try-secure' | 'secure' | 'insecure';
   };
   roles: Array<string>;
   kubernetes_cluster?: string;


### PR DESCRIPTION
A temporary fix until https://github.com/gravitational/teleport/issues/24686 is resolved.
Closes #28 