### PR TITLE
Use CDN for setup action

### DIFF
--- a/actions/setup/package.json
+++ b/actions/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "Apache-2.0",
   "repository": "https://github.com/teleport-actions/setup.git",
   "scripts": {

--- a/actions/setup/src/index.ts
+++ b/actions/setup/src/index.ts
@@ -85,7 +85,7 @@ async function run(): Promise<void> {
   core.info('Could not find Teleport binaries in cache. Fetching...');
   core.debug('Downloading tar');
   const downloadPath = await tc.downloadTool(
-    `https://get.gravitational.com/teleport-${version}-bin.tar.gz`
+    `https://cdn.teleport.dev/teleport-${version}-bin.tar.gz`
   );
 
   core.debug('Extracting tar');


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/26388

Previously we were using `get.gravitational.com`, this was quite slow in many regions. Since the CDN has now been rolled out, we can switch to that which should perform better 🖖 