### PR TITLE
Upgrade to node20

### DIFF
--- a/actions/auth-application/package.json
+++ b/actions/auth-application/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-application",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "Apache-2.0",
   "repository": "https://github.com/teleport-actions/auth-application.git",
   "scripts": {

--- a/actions/auth-k8s/package.json
+++ b/actions/auth-k8s/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-k8s",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "Apache-2.0",
   "repository": "https://github.com/teleport-actions/auth-k8s.git",
   "scripts": {
@@ -12,6 +12,6 @@
   },
   "private": true,
   "devDependencies": {
-    "@types/node": "^18.8.2"
+    "@types/node": "^20.11.16"
   }
 }

--- a/actions/auth/package.json
+++ b/actions/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "Apache-2.0",
   "repository": "https://github.com/teleport-actions/auth.git",
   "scripts": {
@@ -12,6 +12,6 @@
   },
   "private": true,
   "devDependencies": {
-    "@types/node": "^18.8.2"
+    "@types/node": "^20.11.16"
   }
 }

--- a/actions/setup/package.json
+++ b/actions/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "license": "Apache-2.0",
   "repository": "https://github.com/teleport-actions/setup.git",
   "scripts": {
@@ -12,6 +12,6 @@
   },
   "private": true,
   "devDependencies": {
-    "@types/node": "^18.8.2"
+    "@types/node": "^20.11.16"
   }
 }

--- a/common/action.yml
+++ b/common/action.yml
@@ -19,5 +19,5 @@ branding:
   icon: terminal
   color: 'purple'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/yarn.lock
+++ b/yarn.lock
@@ -111,6 +111,13 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.9.tgz#02d013de7058cea16d36168ef2fc653464cfbad4"
   integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
 
+"@types/node@^20.11.16":
+  version "20.11.16"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.16.tgz#4411f79411514eb8e2926f036c86c9f0e4ec6708"
+  integrity sha512-gKb0enTmRCzXSSUJDq6/sPcqrfCv2mkkG6Jt/clpn5eiCbKTY+SgZUxo+p8ZKMof5dCp9vHQUAB7wOUTod22wQ==
+  dependencies:
+    undici-types "~5.26.4"
+
 "@types/semver@^7.3.12":
   version "7.3.13"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
@@ -1221,7 +1228,7 @@ semver@^6.1.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.7:
+semver@^7.3.7, semver@^7.5.4:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
@@ -1366,6 +1373,11 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
node18 is now deprecated

Users now see
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: teleport-actions/setup@v1, teleport-actions/auth-k8s@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```