### PR TITLE
Fix variables from previous invocation breaking second invocation

### DIFF
--- a/common/lib/tbot.ts
+++ b/common/lib/tbot.ts
@@ -148,6 +148,13 @@ export function baseEnvFromSharedInputs(
   env['_TBOT_TELEMETRY_HELPER'] = name;
   env['_TBOT_TELEMETRY_HELPER_VERSION'] = version;
 
+  // Some environment variables are set by our actions and can then end up
+  // being used by a second call to our actions. This causes an error as both
+  // variables for proxy and auth addr can be set and tbot rejects this. Since
+  // we're explicitly configuring tbot, we can remove these variables.
+  delete env['TELEPORT_PROXY'];
+  delete env['TELEPORT_AUTH_SERVER'];
+
   return env;
 }
 


### PR DESCRIPTION
TBot refuses to start if both the Proxy and Auth address is configured. The `teleport-actions/auth` action sets both environment variables. If you invoke the action a second time, these env vars are passed to `tbot` and this results in an error. This PR clears the variables since we want to explicitly configure this anyway.

closes https://github.com/teleport-actions/root/issues/44