### PR TITLE
fix: Add option to exclude auth-server env var output

### DIFF
--- a/actions/auth/src/index.ts
+++ b/actions/auth/src/index.ts
@@ -36,10 +36,14 @@ async function run() {
 
   const identityFilePath = path.join(destinationPath, 'identity');
   const sshConfigFilePath = path.join(destinationPath, 'ssh_config');
+  const export_auth_server = sharedInputs.export_auth_server;
   core.setOutput('identity-file', identityFilePath);
   core.setOutput('ssh-config', sshConfigFilePath);
   core.exportVariable('TELEPORT_PROXY', sharedInputs.proxy);
-  core.exportVariable('TELEPORT_AUTH_SERVER', sharedInputs.proxy);
+  // By default, we export the env var to not do any breaking change
+  if (export_auth_server == null && export_auth_server) {
+    core.exportVariable('TELEPORT_AUTH_SERVER', sharedInputs.proxy);
+  }
   core.exportVariable('TELEPORT_IDENTITY_FILE', identityFilePath);
 }
 run().catch(core.setFailed);

--- a/common/lib/tbot.ts
+++ b/common/lib/tbot.ts
@@ -14,6 +14,7 @@ export interface SharedInputs {
   certificateTTL: string;
   anonymousTelemetry: boolean;
   caPins: string[];
+  export_auth_server: boolean;
 }
 
 function stringToBool(str: string): boolean {
@@ -29,6 +30,7 @@ export function getSharedInputs(): SharedInputs {
   const certificateTTL = core.getInput('certificate-ttl');
   const anonymousTelemetry = stringToBool(core.getInput('anonymous-telemetry'));
   const caPins = core.getMultilineInput('ca-pins');
+  const export_auth_server = core.getBooleanInput('export_auth_server');
 
   return {
     proxy,
@@ -36,6 +38,7 @@ export function getSharedInputs(): SharedInputs {
     certificateTTL,
     anonymousTelemetry,
     caPins,
+    export_auth_server,
   };
 }
 


### PR DESCRIPTION
Since [PR #38727][1] in teleport, tbot configuration validation fails when both the proxy server and the auth server are specified. Because the auth-server seems deprecated, the GitHub Action should not automatically export the env var `TELEPORT_AUTH_SERVER`. However, to avoid any breaking changes, I suggest keeping it exported by default.

[1]: https://github.com/gravitational/teleport/pull/38727