### PR TITLE
Add `disable-env-vars` input and document outputs

### DIFF
--- a/actions/auth-application/README.md
+++ b/actions/auth-application/README.md
@@ -72,6 +72,7 @@ jobs:
       - name: Make request
         run: curl --cert ${{ steps.auth.outputs.certificate-file }} --key ${{ steps.auth.outputs.key-file }} https://grafana-example.tele.example.com/api/users
 ```
+
 ## Outputs
 
 This action will output the following values:
@@ -79,4 +80,3 @@ This action will output the following values:
 - `identity-file`: the path to the identity file.
 - `certificate-file`: the path to the client certificate.
 - `key-file`: the path to the private key for the client certificate.
-

--- a/actions/auth-application/README.md
+++ b/actions/auth-application/README.md
@@ -72,3 +72,11 @@ jobs:
       - name: Make request
         run: curl --cert ${{ steps.auth.outputs.certificate-file }} --key ${{ steps.auth.outputs.key-file }} https://grafana-example.tele.example.com/api/users
 ```
+## Outputs
+
+This action will output the following values:
+
+- `identity-file`: the path to the identity file.
+- `certificate-file`: the path to the client certificate.
+- `key-file`: the path to the private key for the client certificate.
+

--- a/actions/auth-application/package.json
+++ b/actions/auth-application/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-application",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "Apache-2.0",
   "repository": "https://github.com/teleport-actions/auth-application.git",
   "scripts": {

--- a/actions/auth-application/src/index.ts
+++ b/actions/auth-application/src/index.ts
@@ -49,6 +49,7 @@ async function run() {
   );
   await tbot.execute(configPath, env);
 
+  core.setOutput('identity-file', path.join(destinationPath, 'identity'));
   core.setOutput('certificate-file', path.join(destinationPath, 'tlscert'));
   core.setOutput('key-file', path.join(destinationPath, 'key'));
 }

--- a/actions/auth-k8s/README.md
+++ b/actions/auth-k8s/README.md
@@ -71,6 +71,26 @@ jobs:
         run: kubectl get pods
 ```
 
+## Environment Variables
+
+By default, this action will set the following environment variables:
+
+- `KUBECONFIG`: the path to the generated Kubernetes configuration file.
+
+This will automatically configure tools like `kubectl` to use the generated
+credentials. However, this can cause issues if you intend to invoke `tbot`
+multiple times.
+
+You can disable this behaviour by setting the `disable-env-vars` input to
+`true`.
+
+## Outputs
+
+This action will output the following values:
+
+- `identity-file`: the path to the identity file.
+- `kubeconfig`: the path to the generated Kubernetes configuration file.
+
 ## Next steps
 
 Read the `teleport-actions/auth-k8s` getting started guide:

--- a/actions/auth-k8s/package.json
+++ b/actions/auth-k8s/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-k8s",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "Apache-2.0",
   "repository": "https://github.com/teleport-actions/auth-k8s.git",
   "scripts": {

--- a/actions/auth-k8s/src/index.ts
+++ b/actions/auth-k8s/src/index.ts
@@ -49,9 +49,13 @@ async function run() {
   );
   await tbot.execute(configPath, env);
 
-  core.exportVariable(
-    'KUBECONFIG',
-    path.join(destinationPath, '/kubeconfig.yaml')
-  );
+  const identityPath = path.join(destinationPath, 'identity');
+  const kubeConfigPath = path.join(destinationPath, 'kubeconfig.yaml');
+  core.setOutput('identity-file', identityPath);
+  core.setOutput('kubeconfig', kubeConfigPath);
+
+  if (!sharedInputs.disableEnvVars) {
+    core.exportVariable('KUBECONFIG', kubeConfigPath);
+  }
 }
 run().catch(core.setFailed);

--- a/actions/auth/README.md
+++ b/actions/auth/README.md
@@ -73,6 +73,28 @@ jobs:
 Note that `tsh` and `tctl` require the flag pointing at the identity file and
 `tctl` also requires the address of the Proxy or Auth Server to be provided.
 
+## Environment Variables
+
+By default, this action will set the following environment variables:
+
+- `TELEPORT_AUTH_SERVER`: the address of the Teleport Auth Server.
+- `TELEPORT_PROXY`: the address of the Teleport Proxy.
+- `TELEPORT_IDENTITY_FILE`: the path to the identity file.
+
+This will automatically configure tools like `tsh` and `tctl` to use the 
+generated credentials. However, this can cause issues if you intend to invoke
+`tbot` multiple times.
+
+You can disable this behaviour by setting the `disable-env-vars` input to
+`true`.
+
+## Outputs
+
+This action will output the following values:
+
+- `identity-file`: the path to the identity file.
+- `ssh-config`: the path to the generated SSH config.
+
 ## Next steps
 
 Read the `teleport-actions/auth` getting started guide:

--- a/actions/auth/README.md
+++ b/actions/auth/README.md
@@ -81,7 +81,7 @@ By default, this action will set the following environment variables:
 - `TELEPORT_PROXY`: the address of the Teleport Proxy.
 - `TELEPORT_IDENTITY_FILE`: the path to the identity file.
 
-This will automatically configure tools like `tsh` and `tctl` to use the 
+This will automatically configure tools like `tsh` and `tctl` to use the
 generated credentials. However, this can cause issues if you intend to invoke
 `tbot` multiple times.
 

--- a/actions/auth/package.json
+++ b/actions/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "Apache-2.0",
   "repository": "https://github.com/teleport-actions/auth.git",
   "scripts": {

--- a/actions/auth/src/index.ts
+++ b/actions/auth/src/index.ts
@@ -38,8 +38,11 @@ async function run() {
   const sshConfigFilePath = path.join(destinationPath, 'ssh_config');
   core.setOutput('identity-file', identityFilePath);
   core.setOutput('ssh-config', sshConfigFilePath);
-  core.exportVariable('TELEPORT_PROXY', sharedInputs.proxy);
-  core.exportVariable('TELEPORT_AUTH_SERVER', sharedInputs.proxy);
-  core.exportVariable('TELEPORT_IDENTITY_FILE', identityFilePath);
+
+  if (!sharedInputs.disableEnvVars) {
+    core.exportVariable('TELEPORT_PROXY', sharedInputs.proxy);
+    core.exportVariable('TELEPORT_AUTH_SERVER', sharedInputs.proxy);
+    core.exportVariable('TELEPORT_IDENTITY_FILE', identityFilePath);
+  }
 }
 run().catch(core.setFailed);

--- a/common/lib/tbot.ts
+++ b/common/lib/tbot.ts
@@ -14,6 +14,7 @@ export interface SharedInputs {
   certificateTTL: string;
   anonymousTelemetry: boolean;
   caPins: string[];
+  disableEnvVars: boolean;
 }
 
 function stringToBool(str: string): boolean {
@@ -29,6 +30,7 @@ export function getSharedInputs(): SharedInputs {
   const certificateTTL = core.getInput('certificate-ttl');
   const anonymousTelemetry = stringToBool(core.getInput('anonymous-telemetry'));
   const caPins = core.getMultilineInput('ca-pins');
+  const disableEnvVars = stringToBool(core.getInput('disable-env-vars'));
 
   return {
     proxy,
@@ -36,6 +38,7 @@ export function getSharedInputs(): SharedInputs {
     certificateTTL,
     anonymousTelemetry,
     caPins,
+    disableEnvVars,
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "common/lib/"
   ],
   "scripts": {
+    "prettier-write": "yarn prettier --write .",
     "prettier-check": "yarn prettier --check .",
     "eslint": "eslint --ext .ts .",
     "lint": "yarn eslint && yarn prettier-check"


### PR DESCRIPTION
Related https://github.com/teleport-actions/root/pull/47

Adds `disable-env-vars` input to disable the automatic configuration of environment variables. Whilst this works in simpler cases, it can be problematic if `tbot` is invoked multiple times during the workflow.

Additionally, I've added a section to the README for each action to describe the outputs it provides.