### PR TITLE
Add `destination-dir` output for auth actions

### DIFF
--- a/actions/auth-application/README.md
+++ b/actions/auth-application/README.md
@@ -17,13 +17,6 @@
 `auth-application` uses Teleport Machine ID to generate credentials for
 accessing an application protected by Teleport.
 
-The action has the following outputs:
-
-- `certificate-file`: the path to the client certificate to use with requests to
-  the application.
-- `key-file`: the path to the private key for the client certificate to use with
-  request to the application.
-
 Pre-requisites:
 
 - **Teleport 14 or above must be used.** Use
@@ -77,6 +70,7 @@ jobs:
 
 This action will output the following values:
 
+- `destination-dir`: the path to the tbot destination folder.
 - `identity-file`: the path to the identity file.
 - `certificate-file`: the path to the client certificate.
 - `key-file`: the path to the private key for the client certificate.

--- a/actions/auth-application/package.json
+++ b/actions/auth-application/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-application",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "license": "Apache-2.0",
   "repository": "https://github.com/teleport-actions/auth-application.git",
   "scripts": {

--- a/actions/auth-application/src/index.ts
+++ b/actions/auth-application/src/index.ts
@@ -49,6 +49,7 @@ async function run() {
   );
   await tbot.execute(configPath, env);
 
+  core.setOutput('destination-dir', destinationPath);
   core.setOutput('identity-file', path.join(destinationPath, 'identity'));
   core.setOutput('certificate-file', path.join(destinationPath, 'tlscert'));
   core.setOutput('key-file', path.join(destinationPath, 'key'));

--- a/actions/auth-k8s/README.md
+++ b/actions/auth-k8s/README.md
@@ -88,6 +88,7 @@ You can disable this behaviour by setting the `disable-env-vars` input to
 
 This action will output the following values:
 
+- `destination-dir`: the path to the tbot destination folder.
 - `identity-file`: the path to the identity file.
 - `kubeconfig`: the path to the generated Kubernetes configuration file.
 

--- a/actions/auth-k8s/package.json
+++ b/actions/auth-k8s/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-k8s",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "license": "Apache-2.0",
   "repository": "https://github.com/teleport-actions/auth-k8s.git",
   "scripts": {

--- a/actions/auth-k8s/src/index.ts
+++ b/actions/auth-k8s/src/index.ts
@@ -51,6 +51,7 @@ async function run() {
 
   const identityPath = path.join(destinationPath, 'identity');
   const kubeConfigPath = path.join(destinationPath, 'kubeconfig.yaml');
+  core.setOutput('destination-dir', destinationPath);
   core.setOutput('identity-file', identityPath);
   core.setOutput('kubeconfig', kubeConfigPath);
 

--- a/actions/auth/README.md
+++ b/actions/auth/README.md
@@ -17,11 +17,6 @@
 `auth` uses Teleport Machine ID to generate a set of credentials which can be
 used with other Teleport client tools such as `tsh` and `tctl`.
 
-The action has the following outputs:
-
-- `identity-file`: the path to the identity file which can be used with `tctl` and `tsh`.
-- `ssh-config`: the path to the generated SSH config which can be used with `ssh`.
-
 Pre-requisites:
 
 - **Teleport 14 or above must be used.** Use
@@ -92,6 +87,7 @@ You can disable this behaviour by setting the `disable-env-vars` input to
 
 This action will output the following values:
 
+- `destination-dir`: the path to the tbot destination folder.
 - `identity-file`: the path to the identity file.
 - `ssh-config`: the path to the generated SSH config.
 

--- a/actions/auth/package.json
+++ b/actions/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "license": "Apache-2.0",
   "repository": "https://github.com/teleport-actions/auth.git",
   "scripts": {

--- a/actions/auth/src/index.ts
+++ b/actions/auth/src/index.ts
@@ -36,6 +36,7 @@ async function run() {
 
   const identityFilePath = path.join(destinationPath, 'identity');
   const sshConfigFilePath = path.join(destinationPath, 'ssh_config');
+  core.setOutput('destination-dir', destinationPath);
   core.setOutput('identity-file', identityFilePath);
   core.setOutput('ssh-config', sshConfigFilePath);
 


### PR DESCRIPTION
Adds a `destination-dir` output with the path of the Machine ID temp directory used by `tbot`. Helpful in cases where you want to pull a different file from the Machine ID config/certs.

Also cleaned up some duplicate documentation in the READMEs.