### PR TITLE
Setup Action: Automatically fetch version based on Proxy version

### DIFF
--- a/actions/setup/README.md
+++ b/actions/setup/README.md
@@ -36,6 +36,25 @@ jobs:
       - name: Install Teleport
         uses: teleport-actions/setup@v1
         with:
+          # specify version as "auto" and provide the address of your Teleport
+          # proxy using the "proxy" input.
+          version: auto
+          proxy: example.teleport.sh:443
+      - run: tsh # tsh, tbot and tctl will now be available
+```
+
+You can also specify a particular version of the Teleport binaries to install:
+
+```yaml
+on:
+  workflow_dispatch: {}
+jobs:
+  demo-setup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Teleport
+        uses: teleport-actions/setup@v1
+        with:
           # version must be specified, and exclude the "v" prefix.
           # check https://goteleport.com/download/ for valid releases.
           version: 12.1.0

--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -3,7 +3,10 @@ description: 'Installs `teleport`, `tsh`, `tbot` and `tctl`.'
 inputs:
   version:
     required: true
-    description: 'Specify the Teleport version without the preceding "v"'
+    description: 'Specify the Teleport version without the preceding "v" or specify "auto" to use the version indicated by your Teleport cluster.'
+  proxy:
+    description: 'Specify the address of your Teleport Proxy, required if version is set to "auto".'
+    required: false
   enterprise:
     required: false
     default: 'false'

--- a/actions/setup/package.json
+++ b/actions/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "license": "Apache-2.0",
   "repository": "https://github.com/teleport-actions/setup.git",
   "scripts": {

--- a/actions/setup/src/index.ts
+++ b/actions/setup/src/index.ts
@@ -62,18 +62,18 @@ function getInputs(): Inputs {
       throw new Error("'version' input should not be prefixed with 'v'");
     }
     const versionRegex =
-        /^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/i;
+      /^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/i;
 
     if (!versionRegex.test(version)) {
       throw new Error(
-          "incorrect 'version' specified, it should include all parts of the version e.g 11.0.1 or be set to 'auto'"
+        "incorrect 'version' specified, it should include all parts of the version e.g 11.0.1 or be set to 'auto'"
       );
     }
   } else {
     if (proxyAddr === '') {
-        throw new Error(
-            "'proxy' input must be non-empty when 'version' is set to 'auto'"
-        );
+      throw new Error(
+        "'proxy' input must be non-empty when 'version' is set to 'auto'"
+      );
     }
   }
 
@@ -100,7 +100,7 @@ async function run(): Promise<void> {
   const inputs = getInputs();
 
   if (inputs.version === 'auto') {
-    core.info(`Fetching version from proxy: ${inputs.proxyAddr}`)
+    core.info(`Fetching version from proxy: ${inputs.proxyAddr}`);
     const proxyVersion = await fetchVersionFromProxy(inputs.proxyAddr);
     core.info(`Fetched version: ${proxyVersion}`);
     inputs.version = proxyVersion;


### PR DESCRIPTION
Adds `auto` mode to the version field that fetches the version based on the Proxy Version. Removes the need to manually manage versioning.

Closes https://github.com/gravitational/teleport/issues/47659