### PR TITLE
Support configuring `allow_reissue`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+[*]
+indent_size = 2
+indent_style = space

--- a/actions/auth-application/README.md
+++ b/actions/auth-application/README.md
@@ -19,7 +19,7 @@ accessing an application protected by Teleport.
 
 Pre-requisites:
 
-- **Teleport 14 or above must be used.** Use
+- **Teleport 16 or above must be used.** Use
   [`teleport-actions/auth-application@v1`](https://github.com/teleport-actions/auth-application/tree/v1)
   for compatability with older versions of Teleport.
 - Teleport binaries must already be installed in the job environment.
@@ -44,7 +44,10 @@ jobs:
       - name: Install Teleport
         uses: teleport-actions/setup@v1
         with:
-          version: 14.0.0
+          # specify version as "auto" and provide the address of your Teleport
+          # proxy using the "proxy" input.
+          version: auto
+          proxy: tele.example.com:443
       - name: Fetch application credentials
         id: auth
         uses: teleport-actions/auth-application@v2

--- a/actions/auth-application/src/index.ts
+++ b/actions/auth-application/src/index.ts
@@ -21,7 +21,7 @@ function getInputs(): Inputs {
 }
 
 async function run() {
-  await tbot.ensureMinimumVersion('14.0.0');
+  await tbot.ensureMinimumVersion('16.0.0');
 
   const inputs = getInputs();
   const sharedInputs = tbot.getSharedInputs();

--- a/actions/auth-k8s/README.md
+++ b/actions/auth-k8s/README.md
@@ -23,7 +23,7 @@ requested Kubernetes cluster without additional configuration.
 
 Pre-requisites:
 
-- **Teleport 14 or above must be used.** Use
+- **Teleport 16 or above must be used.** Use
   [`teleport-actions/auth-k8s@v1`](https://github.com/teleport-actions/auth-k8s/tree/v1)
   for compatability with older versions of Teleport.
 - Teleport binaries must already be installed in the job environment.
@@ -50,7 +50,10 @@ jobs:
       - name: Install Teleport
         uses: teleport-actions/setup@v1
         with:
-          version: 14.0.0
+          # specify version as "auto" and provide the address of your Teleport
+          # proxy using the "proxy" input.
+          version: auto
+          proxy: tele.example.com:443
       - name: Authorize against Teleport
         uses: teleport-actions/auth-k8s@v2
         with:

--- a/actions/auth-k8s/src/index.ts
+++ b/actions/auth-k8s/src/index.ts
@@ -21,7 +21,7 @@ function getInputs(): Inputs {
 }
 
 async function run() {
-  await tbot.ensureMinimumVersion('14.0.0');
+  await tbot.ensureMinimumVersion('16.0.0');
 
   const inputs = getInputs();
   const sharedInputs = tbot.getSharedInputs();

--- a/actions/auth/README.md
+++ b/actions/auth/README.md
@@ -19,7 +19,7 @@ used with other Teleport client tools such as `tsh` and `tctl`.
 
 Pre-requisites:
 
-- **Teleport 14 or above must be used.** Use
+- **Teleport 16 or above must be used.** Use
   [`teleport-actions/auth@v1`](https://github.com/teleport-actions/auth/tree/v1)
   for compatability with older versions of Teleport.
 - Teleport binaries must already be installed in the job environment.
@@ -41,7 +41,10 @@ jobs:
       - name: Install Teleport
         uses: teleport-actions/setup@v1
         with:
-          version: 14.0.0
+          # specify version as "auto" and provide the address of your Teleport
+          # proxy using the "proxy" input.
+          version: auto
+          proxy: tele.example.com:443
       - name: Authorize against Teleport
         id: auth
         uses: teleport-actions/auth@v2
@@ -67,6 +70,20 @@ jobs:
 
 Note that `tsh` and `tctl` require the flag pointing at the identity file and
 `tctl` also requires the address of the Proxy or Auth Server to be provided.
+
+## Inputs
+
+The following inputs are required:
+
+- `proxy`: String. The publically accessible address of your Teleport Proxy.
+- `token`: String. The name of the GitHub join token for your bot.
+
+The following inputs are optional:
+
+- `allow-reissue`: Boolean. If set to `true`, the action will issue an identity
+  file that permits reissuance. This allows the identity file to be used with
+  `tsh` commands that require new certificates to be issued, such as
+  `tsh db login`.
 
 ## Environment Variables
 

--- a/actions/auth/action.yml
+++ b/actions/auth/action.yml
@@ -1,4 +1,8 @@
 name: 'Teleport Auth'
 description: "Authenticates your workflow so it can use Teleport's `tctl` and `tsh` with the magic of Machine ID."
+inputs:
+  allow-reissue:
+    description: 'Allows the generated identity file to be reissued by other tools. This enables it to work correctly with commands like `tsh db login`. Requires V17.2.8 or later.'
+    default: 'false'
 extend:
   - from: '@/common/action.yml'

--- a/actions/auth/package.json
+++ b/actions/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "license": "Apache-2.0",
   "repository": "https://github.com/teleport-actions/auth.git",
   "scripts": {

--- a/actions/auth/src/index.ts
+++ b/actions/auth/src/index.ts
@@ -8,10 +8,21 @@ import { DirectoryDestination, IdentityOutput } from '@root/lib/tbot';
 
 const { version } = require('../package.json');
 
+interface Inputs {
+    allowReissue: boolean;
+}
+
+function getInputs(): Inputs {
+    return {
+        allowReissue: core.getBooleanInput('allow-reissue'),
+    };
+}
+
 async function run() {
-  await tbot.ensureMinimumVersion('14.0.0');
+  await tbot.ensureMinimumVersion('16.0.0');
 
   const sharedInputs = tbot.getSharedInputs();
+  const inputs = getInputs();
   const config = tbot.baseConfigurationFromSharedInputs(sharedInputs);
 
   const destinationPath = await io.makeTempDirectory();
@@ -24,6 +35,14 @@ async function run() {
     },
     roles: [], // Use all assigned to bot,
   };
+  // We only set `allow_reissue` to an explicit value if the input is set to
+  // true. This is because only tbot 17.2.9 and later supports this field, and,
+  // explicitly setting the field to false would cause older tbot versions to
+  // fail to parse. At a later date, we could remove this check and explicitly
+  // set the value to true. Consider this from the v19 release onwards.
+  if (inputs.allowReissue) {
+      output.allow_reissue = true;
+  }
   config.outputs.push(output);
 
   const configPath = await tbot.writeConfiguration(config);

--- a/common/lib/tbot.ts
+++ b/common/lib/tbot.ts
@@ -58,6 +58,7 @@ export interface IdentityOutput {
   type: 'identity';
   destination: Destination;
   roles: Array<string>;
+  allow_reissue?: boolean;
 }
 
 export interface KubernetesOutput {


### PR DESCRIPTION
Solves https://github.com/teleport-actions/root/issues/51

Also:

- Updates documentation for other actions to demonstrate auto upgrades.
- Adds an .editorconfig to set the correct idents.
- Bumps the minimum compatible version of Teleport to match the minimum supported version of Teleport itself. This will allow us to adjust configuration for some more recent deprecations.