### PR TITLE
Document `disable-env-vars` input correctly

### DIFF
--- a/actions/auth/README.md
+++ b/actions/auth/README.md
@@ -84,6 +84,9 @@ The following inputs are optional:
   file that permits reissuance. This allows the identity file to be used with
   `tsh` commands that require new certificates to be issued, such as
   `tsh db login`.
+- `disable-env-vars`: Boolean. If set to true, the action will not set
+  `TELEPORT_AUTH_SERVER`, `TELEPORT_PROXY` and `TELEPORT_IDENTITY_FILE`
+  environment variables.
 
 ## Environment Variables
 

--- a/common/action.yml
+++ b/common/action.yml
@@ -15,6 +15,9 @@ inputs:
   ca-pins:
     description: 'Specifies one or more trusted CAs to initially validate the identity of the Auth Server when connecting directly to it. This is not required for Teleport Cloud or when connecting via a Teleport Proxy'
     required: false
+  disable-env-vars:
+    description: 'Disables the automatic setting of environment variables like`TELEPORT_IDENTITY_FILE` by the action. This can be useful in more complex workflows where multiple identities are being used.'
+    required: false
 branding:
   icon: terminal
   color: 'purple'


### PR DESCRIPTION
This was missing from our `action.yml`, which has confused a customer when we recommended setting this option. I've also more explicitly described it in the README for the `teleport-actions/auth` action.